### PR TITLE
allow single parameter in constructor

### DIFF
--- a/include/tight_pair.h
+++ b/include/tight_pair.h
@@ -963,7 +963,7 @@ namespace cruft
                     bool
                 > = false
             >
-            constexpr explicit tight_pair(T1 const& first, T2 const& second)
+            constexpr explicit tight_pair(T1 const& first, T2 const& second = {})
                 noexcept(std::is_nothrow_copy_constructible_v<T1> &&
                          std::is_nothrow_copy_constructible_v<T2>):
                 detail::tight_pair_storage<T1, T2>(first, second)
@@ -977,7 +977,7 @@ namespace cruft
                     bool
                 > = false
             >
-            constexpr tight_pair(T1 const& first, T2 const& second)
+            constexpr tight_pair(T1 const& first, T2 const& second = {})
                 noexcept(std::is_nothrow_copy_constructible_v<T1> &&
                          std::is_nothrow_copy_constructible_v<T2>):
                 detail::tight_pair_storage<T1, T2>(first, second)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ set(
 add_executable(
     tight_pair-testsuite
 
+    single_parameter.cpp
     main.cpp
     cppreference.cpp
     dr-811.cpp

--- a/tests/single_parameter.cpp
+++ b/tests/single_parameter.cpp
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Morwenn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <catch2/catch.hpp>
+#include <tight_pair.h>
+
+struct empty
+{};
+constexpr bool operator==(empty e1, empty e2) noexcept
+{
+	return true;
+}
+
+TEST_CASE( "single argument" )
+{
+    using cruft::get;
+
+    cruft::tight_pair<char*, empty> p(0);
+    CHECK(get<0>(p) == nullptr);
+    CHECK(get<1>(p) == empty{});
+}


### PR DESCRIPTION
Rationale:
------------

When using tight(compressed) pair, if we hope to get ebco, empty class is needed. An empty must have no member variable, which means its constructor will not have parameter. 
For example: 
```
template<bool Udummy = true,
			class = EnableIfDeleterDefaultConstructible<Udummy>>
		constexpr unique_ptr() noexcept : pair(pointer(), {})
		{}
```

Here `{}` creates a `default_deleter` for `unique_ptr`, but because the original `tight_pair` must accept two arguments, so `{}` is a must. But I don't think it's necessary. This commit simplifies the initialization to ` pair(pointer())`. 